### PR TITLE
Re-casted to int16_t to prevent trunc.

### DIFF
--- a/application_demo/audiomark.c
+++ b/application_demo/audiomark.c
@@ -229,10 +229,10 @@ audiomark_run(void)
             }
 
             // TODO: ptorelli: return status should be checked!
-            arm_beamformer_f32(NODE_RUN, (void *)&p_bmf_inst, xdais_bmf, 0);
-            xiph_libspeex_aec_f32(NODE_RUN, (void *)&p_aec_inst, xdais_aec, 0);
-            xiph_libspeex_anr_f32(NODE_RUN, (void *)&p_anr_inst, xdais_anr, 0);
-            ee_kws_f32(NODE_RUN, (void *)&p_kws_inst, xdais_kws, 0);
+            arm_beamformer_f32(NODE_RUN, (void **)&p_bmf_inst, xdais_bmf, 0);
+            xiph_libspeex_aec_f32(NODE_RUN, (void **)&p_aec_inst, xdais_aec, 0);
+            xiph_libspeex_anr_f32(NODE_RUN, (void **)&p_anr_inst, xdais_anr, 0);
+            ee_kws_f32(NODE_RUN, (void **)&p_kws_inst, xdais_kws, 0);
 
 #else
 #if TEST_BF

--- a/components/arm/audio_beamformer/src/arm_beamformer_f32.c
+++ b/components/arm/audio_beamformer/src/arm_beamformer_f32.c
@@ -115,17 +115,16 @@ int32_t arm_beamformer_f32(int32_t command, void **instance, void *data, void *p
             PTR_INT *pt_pt=0;
             uint32_t buffer1_size, buffer2_size;
             int32_t nb_input_samples, input_samples_consumed, output_samples_produced;
-            uint8_t *inBufs1stChannel=0, *inBufs2ndChannel=0, *outBufs;
+            int16_t *inBufs1stChannel=0, *inBufs2ndChannel=0, *outBufs;
 
             /* parameter points to input { (*,n),(*,n),..} */
 
             pt_pt = (PTR_INT *)data;
-            inBufs1stChannel = (uint8_t *)(*pt_pt++);
+            inBufs1stChannel = (int16_t *)(*pt_pt++);
             buffer1_size =     (uint32_t )(*pt_pt++);
-            inBufs2ndChannel = (uint8_t *)(*pt_pt++);
+            inBufs2ndChannel = (int16_t *)(*pt_pt++);
             buffer2_size =     (uint32_t )(*pt_pt++);
-            outBufs = (uint8_t *)(*pt_pt++); 
-
+            outBufs = (int16_t *)(*pt_pt++); 
             nb_input_samples = buffer1_size / sizeof(int16_t);
             arm_beamformer_f32_run(&bf_instance, (int16_t *)inBufs1stChannel,  
                                          (int16_t *)inBufs2ndChannel, nb_input_samples, 

--- a/components/xiph/echo_canceller/src/xiph_aec.c
+++ b/components/xiph/echo_canceller/src/xiph_aec.c
@@ -118,16 +118,16 @@ int32_t xiph_libspeex_aec_f32 (int32_t command, void **instance, void *data, voi
             PTR_INT *pt_pt=0;
             uint32_t buffer_size;
             int32_t nb_input_samples;
-            uint8_t *reference=0, *echo=0, *outBufs;
+            int16_t *reference=0, *echo=0, *outBufs;
 
             /* parameter points to input { (*,n),(*,n),..} updated at the end */
 
             pt_pt = (PTR_INT *)data;
-            reference = (uint8_t *)(*pt_pt++);
+            reference = (int16_t *)(*pt_pt++);
             buffer_size = (uint32_t )(*pt_pt++);
-            echo = (uint8_t *)(*pt_pt++);
+            echo = (int16_t *)(*pt_pt++);
             buffer_size = (uint32_t )(*pt_pt++);
-            outBufs = (uint8_t *)(*pt_pt++); 
+            outBufs = (int16_t *)(*pt_pt++); 
 
             nb_input_samples = buffer_size / sizeof(int16_t);
             speex_echo_cancellation((SpeexEchoState *)*instance, 

--- a/components/xiph/preprocess/src/xiph_anr.c
+++ b/components/xiph/preprocess/src/xiph_anr.c
@@ -117,12 +117,12 @@ int32_t xiph_libspeex_anr_f32 (int32_t command, void **instance, void *data, voi
             PTR_INT *pt_pt=0;
             uint32_t buffer_size;
             int32_t nb_input_samples;
-            uint8_t *in_place_buffer=0;
+            int16_t *in_place_buffer=0;
 
             /* parameter points to input { (*,n),(*,n),..} updated at the end */
 
             pt_pt = (PTR_INT *)data;
-            in_place_buffer = (uint8_t *)(*pt_pt++);
+            in_place_buffer = (int16_t *)(*pt_pt++);
             buffer_size =     (uint32_t )(*pt_pt++);
             nb_input_samples = buffer_size / sizeof(int16_t);
             speex_preprocess_run((SpeexPreprocessState *)*instance, 


### PR DESCRIPTION
I noticed while creating tests for ABF that the input data was being truncated to 8-bits after the casting in the component interface. E.g., all of the input data to the beamformer was between 0 and 255 instead of +/-2^16-1!

I made the changes for the ABF, AEC, and ANR interfaces.
