### PR TITLE
Fixed Valgrind alerts

### DIFF
--- a/src/ee_abf_f32.c
+++ b/src/ee_abf_f32.c
@@ -229,7 +229,7 @@ beamformer_f32_run(abf_f32_instance_t *p_inst,
          */
         pf32_1 = p_inst->w->PHATNORM;
         pf32_2 = p_inst->w->XY;
-        for (i = 0; i < NFFT; i++)
+        for (i = 0; i < NFFTD2; i++)
         {
             ftmp = *pf32_1++;
             if (ftmp == 0)
@@ -263,7 +263,7 @@ beamformer_f32_run(abf_f32_instance_t *p_inst,
         }
         pf32_out = p_inst->w->allDerot;
         th_absmax_f32(
-            pf32_out, NFFTD2, &(p_inst->w->corr), &(p_inst->w->icorr));
+            pf32_out, LAGSTEP, &(p_inst->w->corr), &(p_inst->w->icorr));
 
         /* SYNTHESIS
            wrot2 = wrot(fixed_lag,:);
@@ -387,7 +387,8 @@ ee_abf_f32(int32_t command, void **pp_inst, void *p_data, void *p_params)
             uint32_t size = (3 * 4) // See note above
                             + sizeof(abf_f32_fastdata_static_t)
                             + sizeof(abf_f32_fastdata_working_t)
-                            + sizeof(float *) + sizeof(float *);
+                            + sizeof(float *) + sizeof(float *)
+                            + 4; /* TODO : justify this */
             *(uint32_t *)(*pp_inst) = size;
             break;
         }

--- a/src/ee_api.h
+++ b/src/ee_api.h
@@ -20,8 +20,10 @@
 #include "dsp/support_functions.h"
 
 void *th_malloc(size_t size, int req);
+void th_free(void * mem, int req);
 void *th_memcpy(void *restrict dst, const void *restrict src, size_t n);
 void *th_memset(void *b, int c, size_t len);
+void *th_memmove(void *restrict dst, const void *restrict src, size_t n);
 
 void th_softmax_i8(const int8_t *vec_in, const uint16_t dim_vec, int8_t *p_out);
 void th_nn_init(void);

--- a/src/ee_audiomark.c
+++ b/src/ee_audiomark.c
@@ -193,6 +193,15 @@ audiomark_initialize(void)
     return 0;
 }
 
+void
+audiomark_release(void)
+{
+    th_free(p_bmf_inst, COMPONENT_BMF);
+    th_free(p_aec_inst, COMPONENT_AEC);
+    th_free(p_anr_inst, COMPONENT_ANR);
+    th_free(p_kws_inst, COMPONENT_KWS);
+}
+
 #define CHECK(X)         \
     if (X == 1)          \
     {                    \

--- a/src/ee_kws.c
+++ b/src/ee_kws.c
@@ -84,7 +84,7 @@ ee_kws_run(kws_instance_t *p_inst,
     if (p_inst->chunk_idx >= CHUNK_WATERMARK)
     {
         /* Shift off the oldest features to make room for the new ones. */
-        th_memcpy(p_inst->p_mfcc_fifo,
+        th_memmove(p_inst->p_mfcc_fifo,
                   p_inst->p_mfcc_fifo + FEATURES_PER_FRAME,
                   (NUM_MFCC_FRAMES - 1) * FEATURES_PER_FRAME);
 
@@ -101,7 +101,7 @@ ee_kws_run(kws_instance_t *p_inst,
 
         /* Shift off the aduio buffer chunks used by the MFCC. */
         p_inst->chunk_idx -= CHUNKS_PER_MFCC_SLIDE;
-        th_memcpy(p_inst->p_audio_fifo,
+        th_memmove(p_inst->p_audio_fifo,
                   p_inst->p_audio_fifo + SAMPLES_PER_OUTPUT_MFCC,
                   p_inst->chunk_idx * SAMPLES_PER_CHUNK * BYTES_PER_SAMPLE);
     }
@@ -133,12 +133,14 @@ ee_kws_f32(int32_t command, void **pp_inst, void *p_data, void *p_params)
              * padding is not outside of a memory region.
              */
             uint32_t size = (3 * 4) // See note above
-                            + sizeof(mfcc_instance_t);
+                            + sizeof(mfcc_instance_t)
+                            + 8; /* TODO : justift this */
             *(uint32_t *)(*pp_inst) = size;
             break;
         }
         case NODE_RESET: {
             ee_kws_init((kws_instance_t *)(*pp_inst));
+            ((kws_instance_t *)(*pp_inst))->chunk_idx = 0;
             break;
         }
         case NODE_RUN: {

--- a/src/ee_main.c
+++ b/src/ee_main.c
@@ -20,6 +20,7 @@
 
 int audiomark_initialize(void);
 int audiomark_run(void);
+void audiomark_release(void);
 
 int
 main(void)
@@ -34,5 +35,8 @@ main(void)
         printf("Run failed\n");
         return -1;
     }
+
+    audiomark_release();
+
     return 0;
 }

--- a/src/ee_mfcc_f32.c
+++ b/src/ee_mfcc_f32.c
@@ -57,7 +57,7 @@ ee_mfcc_f32(mfcc_instance_t *p_inst)
 
     /* Apply MEL filters */
     /* N.B. This overwrites p_src and reliquinshes p_inst->tmp */
-    th_cmplx_mag_f32(p_inst->tmp, p_src, FFT_LEN);
+    th_cmplx_mag_f32(p_inst->tmp, p_src, FFT_LEN / 2);
     for (int i = 0; i < EE_NUM_MFCC_FILTER_CONFIG; i++)
     {
         /* p_inst->tmp[i] is now the MEL energy for that bin. */

--- a/src/th_api.c
+++ b/src/th_api.c
@@ -48,10 +48,31 @@ th_malloc(size_t size, int req)
     }
 }
 
+void
+th_free(void * mem, int req)
+{
+    switch (req)
+    {
+        // The system integrator can assign working memory wherever they like
+        case COMPONENT_BMF:
+        case COMPONENT_AEC:
+        case COMPONENT_ANR:
+        case COMPONENT_KWS:
+        default:
+            return free(mem);
+    }
+}
+
 void *
 th_memcpy(void *restrict dst, const void *restrict src, size_t n)
 {
     return memcpy(dst, src, n);
+}
+
+void *
+th_memmove(void *restrict dst, const void *restrict src, size_t n)
+{
+    return memmove(dst, src, n);
 }
 
 void *
@@ -534,3 +555,4 @@ th_nn_classify(const int8_t *in_data, int8_t *out_data)
                            out_data,
                            (q15_t *)col_buffer);
 }
+


### PR DESCRIPTION
Valgrind reported issues fixed
To be validated by audiomark team, especially constants added by node memory requests

Added optional 
 - memmove to handle memcopy with overlap
 - th_free to release memory
