### PR TITLE
ML Model Zoo path update + ARM CM55 C300 scatter file update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ integrator must implement. The components were derived from several sources:
 
 * The beaformer and direction of arrival algorithms (BF+DOA) were written and tested by Arm and Infineon.
 * The acoustic echo canceller (AEC) and audio noise  reduction (ANR) elements are implemented by the SpeeX libspeexdsp library. These functions utilize the SpeeX API, which is a combination of macros and functions that perform fixed math operations, and an FFT wrapper for transformation.
-* The neural net was derived from the [Arm Model Zoo DS CNN KWS](https://github.com/ARM-software/ML-zoo/tree/master/models/keyword_spotting/ds_cnn_small/tflite_int8).
+* The neural net was derived from the [Arm Model Zoo DS CNN KWS](https://github.com/ARM-software/ML-zoo/tree/master/models/keyword_spotting/ds_cnn_small/model_package_tf/model_archive/TFLite/tflite_int8).
 
 This flexibility to utilize whatever hardware is available means the benchmark 
 scales across a wide variety of MCUs and SoCs.

--- a/platform/cmsis/RTE/Device/SSE-300-MPS3/fvp_sse300_mps3_s.sct
+++ b/platform/cmsis/RTE/Device/SSE-300-MPS3/fvp_sse300_mps3_s.sct
@@ -23,6 +23,8 @@ LR_CODE S_CODE_START {
     ER_CODE S_CODE_START {
         *.o (RESET +First)
         .ANY (+RO)
+        th_api.o
+        * (InRoot$$Sections)
     }
 
     /*
@@ -55,7 +57,7 @@ LR_CODE S_CODE_START {
     ScatterAssert(ImageLimit(CODE_WATERMARK) <= S_CODE_START + S_CODE_SIZE)
 
     ER_DATA S_DATA_START {
-        .ANY (+ZI +RW)
+        .ANY (+ZI +RW +RO-DATA)
     }
 
     #if HEAP_SIZE > 0


### PR DESCRIPTION
- AudioMark KWS derived from ARM ML Model Zoo tree restructuring has been moved in
https://github.com/ARM-software/ML-zoo/tree/master/models/keyword_spotting/ds_cnn_small/model_package_tf/model_archive/TFLite/tflite_int8

- Linker script is placing all RO-DATA in DTCM
