### PR TITLE
Fix integer overflow check in multiply_frac

### DIFF
--- a/lib/speexdsp/libspeexdsp/resample.c
+++ b/lib/speexdsp/libspeexdsp/resample.c
@@ -592,13 +592,11 @@ static int resampler_basic_zero(SpeexResamplerState *st, spx_uint32_t channel_in
 
 static int multiply_frac(spx_uint32_t *result, spx_uint32_t value, spx_uint32_t num, spx_uint32_t den)
 {
-   spx_uint32_t major = value / den;
-   spx_uint32_t remain = value % den;
-   /* TODO: Could use 64 bits operation to check for overflow. But only guaranteed in C99+ */
-   if (remain > UINT32_MAX / num || major > UINT32_MAX / num
-       || major * num > UINT32_MAX - remain * num / den)
+   unsigned long long major = (unsigned long long)value * num;
+   unsigned long long res = major / den;
+   if (res > UINT32_MAX)
       return RESAMPLER_ERR_OVERFLOW;
-   *result = remain * num / den + major * num;
+   *result = (spx_uint32_t)res;
    return RESAMPLER_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
**Description:**
This PR replaces the fragile 32-bit overflow detection logic in `multiply_frac` (in `resample.c`) with safer, standard 64-bit arithmetic.

**Changes:**
- Implementation of `multiply_frac` updated to cast operands to `unsigned long long` before multiplication.
- Verified overflow detection by comparing the result against `UINT32_MAX`.
- Removes the complex and potentially incomplete conditional logic previously used to guess overflows.

**Motivation:**
The original code contained a TODO comment acknowledging the method was suboptimal: `/* TODO: Could use 64 bits operation to check for overflow. But only guaranteed in C99+ */`. Since modern build environments support C99/64-bit integers, this change improves code safety and maintainability, ensuring that buffer sizes for the resampler are calculated correctly without wrapping.

Related Issues: #88 