### PR TITLE
Fix CY0 buffer overflow in beamformer working struct

### DIFF
--- a/src/ee_abf_f32.h
+++ b/src/ee_abf_f32.h
@@ -65,7 +65,7 @@ typedef struct abf_f32_fastdata_working_t
     ee_f32_t BF[NFFT * COMPLEX + 2];
     ee_f32_t X0[NFFT * COMPLEX + 2];
     ee_f32_t Y0[NFFT * COMPLEX + 2];
-    ee_f32_t CY0[NFFTD2 * COMPLEX + 2];
+    ee_f32_t CY0[NFFT * COMPLEX + 2];
     ee_f32_t XY[NFFTD2 * COMPLEX];
     ee_f32_t PHATNORM[NFFTD2 * COMPLEX];
     ee_f32_t allDerot[LAGSTEP];


### PR DESCRIPTION

## Summary
Identified and fixed a buffer overflow in the `CY0` scratch buffer.

The buffer was declared using the half-spectrum constant (`NFFTD2`), but the synthesis logic treats it as full-spectrum (`NFFT`). This resulted in writing 126 floats (504 bytes) past the end of the array during the IFFT and spectrum extension stages.

On the current ARM build, this overflow was overwriting the adjacent `XY` struct member. It did not trigger a crash solely due to the specific memory layout and the fact that `XY` was effectively unused at that point in the frame. This fix updates `CY0` to the correct full-spectrum size to prevent the out-of-bounds writes.

## The Bug
The `CY0` buffer was declared with `NFFTD2` (half-spectrum size), likely because it's used for some half-spectrum math early in the function.

**However**, later in the synthesis stage (specifically the complex IFFT), we treat `CY0` as a *full-spectrum* buffer. We end up writing about 126 floats past the end of the array.


## The Fix
I just bumped the size of `CY0` to match the other full-spectrum buffers (`mic`, `BM`, etc).

```c
// src/ee_abf_f32.h
- ee_f32_t CY0[NFFTD2 * COMPLEX + 2]; // Too small (130 floats)
+ ee_f32_t CY0[NFFT * COMPLEX + 2];   // Correct (258 floats)