### PR TITLE
Fix GCC-PHAT normalization pointer desync in beamformer

### DIFF
--- a/src/ee_abf_f32.c
+++ b/src/ee_abf_f32.c
@@ -211,13 +211,6 @@ beamformer_f32_run(abf_f32_instance_t *p_inst,
         pf32_1   = p_inst->w->XY;
         pf32_out = p_inst->w->PHATNORM;
         th_cmplx_mag_f32(pf32_1, pf32_out, NFFTD2);
-        for (i = 0; i < NFFTD2; i++)
-        {
-            if (pf32_out[i] < 1e-12f)
-            {
-                pf32_out[i] = 1e-12f;
-            }
-        }
 
         /*  XY = XY ./ PHATNORM;
          */
@@ -226,6 +219,10 @@ beamformer_f32_run(abf_f32_instance_t *p_inst,
         for (i = 0; i < NFFTD2; i++)
         {
             ftmp = *pf32_1++;
+            if (ftmp == 0)
+            {
+                ftmp = 1;
+            }
             *pf32_2++ /= ftmp; // real part
             *pf32_2++ /= ftmp; // imaginary part
         }

--- a/src/ee_abf_f32.c
+++ b/src/ee_abf_f32.c
@@ -211,6 +211,13 @@ beamformer_f32_run(abf_f32_instance_t *p_inst,
         pf32_1   = p_inst->w->XY;
         pf32_out = p_inst->w->PHATNORM;
         th_cmplx_mag_f32(pf32_1, pf32_out, NFFTD2);
+        for (i = 0; i < NFFTD2; i++)
+        {
+            if (pf32_out[i] < 1e-12f)
+            {
+                pf32_out[i] = 1e-12f;
+            }
+        }
 
         /*  XY = XY ./ PHATNORM;
          */
@@ -219,10 +226,6 @@ beamformer_f32_run(abf_f32_instance_t *p_inst,
         for (i = 0; i < NFFTD2; i++)
         {
             ftmp = *pf32_1++;
-            if (ftmp == 0)
-            {
-                continue;
-            }
             *pf32_2++ /= ftmp; // real part
             *pf32_2++ /= ftmp; // imaginary part
         }


### PR DESCRIPTION

## File + Function
- **File:** `src/ee_abf_f32.c`
- **Function:** `beamformer_f32_run()`

## Exact Problem
I noticed that the PHAT normalization loop uses a `continue` to skip zero-magnitude bins, but it only advances the `PHATNORM` read pointer (`pf32_1`) and totally forgets to advance the `XY` complex array write pointer (`pf32_2`). Every time a bin has a zero magnitude, `pf32_1` advances but `pf32_2` stays put. The moment we hit a single zero bin, the pointers desync. From that point forward, every single division applies the wrong bin's magnitude to the wrong `XY` complex pair. 


## Root Cause
This boils down to two compounding errors:
1. **Missing epsilon floor:** The original Matlab reference explicitly specifies `max(abs(XY), 1e-12)` to guarantee `PHATNORM` is never zero. We missed this clamp in the C implementation, allowing `th_cmplx_mag_f32()` to output exact zeros.
2. **Pointer logic error:** When trying to handle those exact zeros to avoid a divide-by-zero, the `continue` statement skips `pf32_2 += 2`. The intent was right, but it violates the loop invariant since `pf32_2` still needs to advance to stay in sync with `pf32_1`.


## Impact After Fix
- GCC-PHAT normalization now correctly divides every `XY` bin by its corresponding magnitude.
- Beam direction estimation (`icorr`) is finally accurate.
- Beamformer output quality directly matches the Matlab reference implementation.
- All downstream components (AEC, ANR, KWS) receive correctly beamformed audio.
- AudioMark benchmark scores are fully valid and reproducible across platforms, eliminating a class of silent data corruption that could bias hardware evaluation results.