### PR TITLE
Fix KWS NODE_MEMREQ instance header underallocation

### DIFF
--- a/src/ee_kws.c
+++ b/src/ee_kws.c
@@ -158,8 +158,7 @@ ee_kws_f32(int32_t command, void **pp_inst, void *p_data, void *p_params)
              * padding is not outside of a memory region.
              */
             uint32_t size = (3 * 4) // See note above
-                            + sizeof(mfcc_instance_t)
-                            + 8; /* TODO : justift this */
+                            + sizeof(kws_instance_t);
             *(uint32_t *)(*pp_inst) = size;
             break;
         }


### PR DESCRIPTION

While looking at the recent ABF memory patch (commit edc44cf), I noticed the exact same under-allocation bug exists in the KWS component.

### The Bug
In `src/ee_kws.c`, `NODE_MEMREQ` allocates memory using a magic number: `sizeof(mfcc_instance_t) + 8`. The `+ 8` was probably meant to cover two 32-bit pointers, but it ignores the `chunk_idx` field entirely and breaks on 64-bit platforms (where pointers are 8 bytes). There's literally a `/* TODO : justift this */` comment sitting right next to it.

Because of this, the `kws_instance_t` struct overflows its heap block. This eats into the 12-byte CMSIS vectorized-read safety padding, leading to undefined behavior. On 64-bit RISC-V evaluation targets, this overflow can silently corrupt heap metadata or cause sliding window drifts that completely invalidate benchmark scores.

### The Fix
I mirrored the ABF fix by replacing the manual calculation with a standard `sizeof(kws_instance_t)`. Since the struct already includes `mfcc_instance_t` as its first member, this naturally accounts for all pointers, `chunk_idx`, and any compiler-inserted alignment padding across all architectures and pointer widths.

```c
// Before:
uint32_t size = (3 * 4) // See note above
                + sizeof(mfcc_instance_t)
                + 8; /* TODO : justift this */

// After:
uint32_t size = (3 * 4) // See note above
                + sizeof(kws_instance_t);
```

This restores the full CMSIS 12-byte guard padding, eliminates the undefined behavior risk, and brings KWS up to the same correctness baseline as ABF.