### PR TITLE
Fix Typo From Throughtout to Throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ FFTs.
 * th_vlog_f32
 * th_mat_vec_mult_f32
 
-Throughtout the EEMBC code, these functions perform the heavy-lifting.
+Throughout the EEMBC code, these functions perform the heavy-lifting.
 
 ### Neural-net functions
 


### PR DESCRIPTION
I got one Typo in The readme file , So i made changes in the readme file . From Throughtout to throughout .